### PR TITLE
Add script version flag and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ chmod +x troubleshooter.sh
 ./troubleshooter.sh --run --tool "Firewall Check" --category "System Diagnostics"
 ```
 
+### Check version
+
+```bash
+./troubleshooter.sh --version
+```
+
 ### Options
 - `--config PATH`     Path to `tools.conf` (default: ./tools.conf)
 - `--page-size N`     Items per page in menu (default: 8)
@@ -51,6 +57,17 @@ Automated smoke tests cover key behaviours such as runtime detection, menu rende
 ```bash
 ./tests/run_tests.sh
 ```
+
+## Versioning workflow
+
+The project tracks its release number through the `SCRIPT_VERSION` constant near the top of `troubleshooter.sh`. To decide when and how to bump it:
+
+1. **Group changes by user impact.** Bug fixes or documentation-only tweaks can share a patch release (e.g., `1.2.3 → 1.2.4`). Backwards-compatible feature work usually merits a minor bump (`1.2.3 → 1.3.0`), while breaking changes or large rewrites justify a major release (`1.2.3 → 2.0.0`).
+2. **Update tests and docs in the same change.** The smoke test suite includes coverage for `--version`; refresh the expected value whenever you increment the constant, and mention notable changes in the README or changelog if present.
+3. **Keep commits focused.** Each version bump should include only the modifications that correspond to the new release. Avoid mixing unrelated refactors with a version update so history stays easy to audit.
+4. **Tag the release when merging.** After the pull request lands, create a git tag (e.g., `git tag v1.3.0 && git push origin v1.3.0`) so downstream users can pin to a specific revision.
+
+If you're ever unsure which increment is appropriate, ask a maintainer for guidance and err on the side of smaller bumps—you can always ship another patch if needed.
 
 The script follows the standard “test first” loop:
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -133,6 +133,22 @@ test_load_tools_handles_empty_search() {
     return 0
 }
 
+test_cli_version_flag() {
+    local output
+    if ! output=$("$ROOT_DIR/troubleshooter.sh" --version); then
+        printf 'version command failed\n'
+        return 1
+    fi
+
+    local expected="Stellar Troubleshoot $SCRIPT_VERSION"
+    if [[ "$output" != "$expected" ]]; then
+        printf 'expected "%s" but got "%s"\n' "$expected" "$output"
+        return 1
+    fi
+
+    return 0
+}
+
 # ---------------------------------------------------------------------------
 
 main() {
@@ -142,6 +158,7 @@ main() {
         test_draw_menu_survives_clear_failure
         test_run_tool_handles_failing_cached_script
         test_load_tools_handles_empty_search
+        test_cli_version_flag
     )
 
     local test

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -41,6 +41,22 @@ run_test() {
     fi
 }
 
+reset_state() {
+    MENU_OPTIONS=()
+    MENU_ACTIONS=()
+    CURSOR=0
+    MODE="categories"
+    SELECTED_CATEGORY=""
+    SELECTED_TOOL_NAME=""
+    SELECTED_TOOL_DESC=""
+    SELECTED_TOOL_URL=""
+    SELECTED_TOOL_RUNTIME=""
+    SEARCH_TERM=""
+    CURRENT_PAGE=0
+    TOTAL_PAGES=0
+    VISIBLE_COUNT=0
+}
+
 # --- Tests -----------------------------------------------------------------
 
 test_detect_runtime_respects_explicit() {
@@ -56,6 +72,7 @@ test_detect_runtime_inferrs_extension() {
 }
 
 test_draw_menu_survives_clear_failure() {
+    reset_state
     MODE="categories"
     MENU_OPTIONS=("First" "Second")
     MENU_ACTIONS=("first" "second")
@@ -79,6 +96,7 @@ test_draw_menu_survives_clear_failure() {
 test_run_tool_handles_failing_cached_script() {
     local tmp_dir
     tmp_dir=$(mktemp -d)
+    local original_base_dir="$BASE_DIR"
     BASE_DIR="$tmp_dir"
     local category="Diag"
     mkdir -p "$BASE_DIR/$category"
@@ -92,6 +110,7 @@ SCRIPT
     local output rc=0
     output=$( { run_tool "$category" "Test Tool" "https://example.com/tool.sh" "bash"; } </dev/null 2>&1 ) || rc=$?
 
+    BASE_DIR="$original_base_dir"
     rm -rf "$tmp_dir"
 
     if [[ $rc -ne 0 ]]; then
@@ -108,6 +127,7 @@ SCRIPT
 }
 
 test_load_tools_handles_empty_search() {
+    reset_state
     MODE="tools"
     SEARCH_TERM="nonexistent-term"
     CURRENT_PAGE=0
@@ -149,16 +169,402 @@ test_cli_version_flag() {
     return 0
 }
 
+test_detect_runtime_defaults_to_bash() {
+    local result
+    result=$(detect_runtime "https://example.com/tool" "")
+    assert_equals "bash" "$result" "test_detect_runtime_defaults_to_bash"
+}
+
+test_pick_python_prefers_python3() {
+    local py
+    py=$(pick_python)
+    if [[ -z "$py" ]]; then
+        printf 'pick_python did not find any interpreter\n'
+        return 1
+    fi
+
+    if command -v python3 >/dev/null 2>&1 && [[ "$py" != "python3" ]]; then
+        printf 'expected python3 but got %s\n' "$py"
+        return 1
+    fi
+
+    return 0
+}
+
+test_load_categories_sorts_and_appends_all() {
+    local tmp_conf
+    tmp_conf=$(mktemp)
+    cat <<'CONF' >"$tmp_conf"
+Category B|Name 1|Desc|https://example.com/b.sh
+Category A|Name 2|Desc|https://example.com/a.sh
+Category B|Name 3|Desc|https://example.com/c.sh
+# Comment line should be ignored
+CONF
+
+    local original_config="$CONFIG_FILE"
+    CONFIG_FILE="$tmp_conf"
+
+    reset_state
+    load_categories
+
+    local expected=("Category A" "Category B" "All tools")
+    if [[ ${#MENU_OPTIONS[@]} -ne ${#expected[@]} ]]; then
+        printf 'expected %d categories but found %d\n' "${#expected[@]}" "${#MENU_OPTIONS[@]}"
+        rm -f "$tmp_conf"
+        CONFIG_FILE="$original_config"
+        return 1
+    fi
+
+    local i
+    for i in "${!expected[@]}"; do
+        if [[ "${MENU_OPTIONS[$i]}" != "${expected[$i]}" ]]; then
+            printf 'expected "%s" at index %d but found "%s"\n' "${expected[$i]}" "$i" "${MENU_OPTIONS[$i]}"
+            rm -f "$tmp_conf"
+            CONFIG_FILE="$original_config"
+            return 1
+        fi
+    done
+
+    CONFIG_FILE="$original_config"
+    rm -f "$tmp_conf"
+    return 0
+}
+
+test_load_tools_paginates_results() {
+    local tmp_conf
+    tmp_conf=$(mktemp)
+    cat <<'CONF' >"$tmp_conf"
+Category|Alpha|First tool|https://example.com/a.sh
+Category|Beta|Second tool|https://example.com/b.sh
+Category|Gamma|Third tool|https://example.com/c.sh
+Category|Delta|Fourth tool|https://example.com/d.sh
+Category|Epsilon|Fifth tool|https://example.com/e.sh
+CONF
+
+    local original_config="$CONFIG_FILE"
+    CONFIG_FILE="$tmp_conf"
+    local original_page_size="$PAGE_SIZE"
+    PAGE_SIZE=2
+
+    reset_state
+    MODE="tools"
+    load_tools "Category"
+
+    if [[ "$TOTAL_PAGES" -ne 3 ]]; then
+        printf 'expected 3 total pages but found %d\n' "$TOTAL_PAGES"
+        PAGE_SIZE="$original_page_size"
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    if [[ "${MENU_OPTIONS[-1]}" != "Back to categories" ]]; then
+        printf 'missing back to categories entry\n'
+        PAGE_SIZE="$original_page_size"
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    local has_next=0 has_prev=0 option
+    for option in "${MENU_OPTIONS[@]}"; do
+        [[ "$option" == "→ Next page" ]] && has_next=1
+        [[ "$option" == "← Prev page" ]] && has_prev=1
+    done
+
+    if (( has_next != 1 || has_prev != 0 )); then
+        printf 'unexpected pagination state on first page (next=%d prev=%d)\n' "$has_next" "$has_prev"
+        PAGE_SIZE="$original_page_size"
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    CURRENT_PAGE=2
+    load_tools "Category"
+
+    has_next=0
+    has_prev=0
+    for option in "${MENU_OPTIONS[@]}"; do
+        [[ "$option" == "→ Next page" ]] && has_next=1
+        [[ "$option" == "← Prev page" ]] && has_prev=1
+    done
+
+    if (( has_next != 0 || has_prev != 1 )); then
+        printf 'unexpected pagination state on last page (next=%d prev=%d)\n' "$has_next" "$has_prev"
+        PAGE_SIZE="$original_page_size"
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    PAGE_SIZE="$original_page_size"
+    CONFIG_FILE="$original_config"
+    rm -f "$tmp_conf"
+    return 0
+}
+
+test_load_tools_search_filters_results() {
+    local tmp_conf
+    tmp_conf=$(mktemp)
+    cat <<'CONF' >"$tmp_conf"
+Category|Alpha|First tool|https://example.com/a.sh
+Category|Beta|Second tool|https://example.com/b.sh
+Category|Gamma|Special needle|https://example.com/c.sh
+CONF
+
+    local original_config="$CONFIG_FILE"
+    CONFIG_FILE="$tmp_conf"
+
+    reset_state
+    MODE="tools"
+    SEARCH_TERM="needle"
+    load_tools "Category"
+
+    if [[ "$VISIBLE_COUNT" -ne 1 ]]; then
+        printf 'expected exactly one visible tool, found %d\n' "$VISIBLE_COUNT"
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    if [[ "${MENU_OPTIONS[0]}" != "Gamma — Special needle" ]]; then
+        printf 'search results did not include expected tool (got "%s")\n' "${MENU_OPTIONS[0]}"
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    if [[ "${MENU_OPTIONS[-1]}" != "Back to categories" ]]; then
+        printf 'missing back navigation for search results\n'
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    CONFIG_FILE="$original_config"
+    rm -f "$tmp_conf"
+    return 0
+}
+
+test_draw_menu_includes_version_and_context() {
+    reset_state
+    MODE="tools"
+    SELECTED_CATEGORY="Networking"
+    VISIBLE_COUNT=3
+    TOTAL_PAGES=2
+    MENU_OPTIONS=("First" "Second")
+    MENU_ACTIONS=("first" "second")
+    CURSOR=0
+
+    local original_clear=$(declare -f clear 2>/dev/null || true)
+    clear() { return 0; }
+
+    local original_colors=("$BOLD" "$RESET" "$CYAN" "$YELLOW")
+    BOLD=""; RESET=""; CYAN=""; YELLOW=""
+
+    local output
+    output=$(draw_menu)
+
+    local expected_header="=== Stellar Troubleshoot v$SCRIPT_VERSION ==="
+    if [[ "$output" != *"$expected_header"* ]]; then
+        printf 'menu header missing version (output: %s)\n' "$output"
+        [[ -n "$original_clear" ]] && eval "$original_clear" || unset -f clear
+        BOLD="${original_colors[0]}"; RESET="${original_colors[1]}"; CYAN="${original_colors[2]}"; YELLOW="${original_colors[3]}"
+        return 1
+    fi
+
+    if [[ "$output" != *"Category: Networking"* ]]; then
+        printf 'menu missing category context\n'
+        [[ -n "$original_clear" ]] && eval "$original_clear" || unset -f clear
+        BOLD="${original_colors[0]}"; RESET="${original_colors[1]}"; CYAN="${original_colors[2]}"; YELLOW="${original_colors[3]}"
+        return 1
+    fi
+
+    [[ -n "$original_clear" ]] && eval "$original_clear" || unset -f clear
+    BOLD="${original_colors[0]}"; RESET="${original_colors[1]}"; CYAN="${original_colors[2]}"; YELLOW="${original_colors[3]}"
+    return 0
+}
+
+test_run_tool_uses_cached_copy_by_default() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local original_base_dir="$BASE_DIR"
+    BASE_DIR="$tmp_dir"
+
+    local category="Diag"
+    mkdir -p "$BASE_DIR/$category"
+    local script_path="$BASE_DIR/$category/Test_Tool.sh"
+    cat <<'SCRIPT' >"$script_path"
+#!/usr/bin/env bash
+echo "cached run"
+SCRIPT
+    chmod +x "$script_path"
+
+    local colors=("$GREEN" "$RESET")
+    GREEN=""; RESET=""
+
+    local output
+    output=$(printf '\n\n' | run_tool "$category" "Test Tool" "https://example.com/tool.sh" "bash")
+
+    BASE_DIR="$original_base_dir"
+    GREEN="${colors[0]}"; RESET="${colors[1]}"
+    rm -rf "$tmp_dir"
+
+    if [[ "$output" != *"Running cached Test Tool..."* ]]; then
+        printf 'expected cached execution path but output was: %s\n' "$output"
+        return 1
+    fi
+
+    if [[ "$output" != *"Tool execution finished."* ]]; then
+        printf 'expected success message but output was: %s\n' "$output"
+        return 1
+    fi
+
+    return 0
+}
+
+test_run_tool_re_downloads_on_request() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local original_base_dir="$BASE_DIR"
+    BASE_DIR="$tmp_dir"
+
+    local category="Diag"
+    mkdir -p "$BASE_DIR/$category"
+    local script_path="$BASE_DIR/$category/Test_Tool.sh"
+    echo '#!/usr/bin/env bash' >"$script_path"
+    chmod +x "$script_path"
+
+    local colors=("$GREEN" "$RESET")
+    GREEN=""; RESET=""
+
+    local marker
+    marker=$(mktemp)
+    local original_curl=$(declare -f curl 2>/dev/null || true)
+    curl() {
+        local out_path=""
+        while [[ "$#" -gt 0 ]]; do
+            case "$1" in
+                -o)
+                    out_path="$2"
+                    shift 2
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        printf 'called' >"$marker"
+        cat <<'SCRIPT' >"$out_path"
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+        return 0
+    }
+
+    local output
+    output=$(printf 'r\n\n' | run_tool "$category" "Test Tool" "https://example.com/tool.sh" "bash")
+
+    [[ -n "$original_curl" ]] && eval "$original_curl" || unset -f curl
+    BASE_DIR="$original_base_dir"
+    GREEN="${colors[0]}"; RESET="${colors[1]}"
+
+    local curl_called=0
+    [[ -f "$marker" ]] && curl_called=1
+    rm -f "$marker"
+    rm -rf "$tmp_dir"
+
+    if (( curl_called == 0 )); then
+        printf 'expected curl to be invoked for re-download\n'
+        return 1
+    fi
+
+    if [[ "$output" != *"Downloading tool..."* ]]; then
+        printf 'expected download message but output was: %s\n' "$output"
+        return 1
+    fi
+
+    return 0
+}
+
+test_run_tool_reports_missing_python() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    local original_base_dir="$BASE_DIR"
+    BASE_DIR="$tmp_dir"
+
+    local category="Diag"
+    mkdir -p "$BASE_DIR/$category"
+    local script_path="$BASE_DIR/$category/Test_Tool.py"
+    cat <<'SCRIPT' >"$script_path"
+#!/usr/bin/env python3
+print("hello")
+SCRIPT
+    chmod +x "$script_path"
+
+    local colors=("$RED" "$RESET")
+    RED=""; RESET=""
+
+    local original_pick_python=$(declare -f pick_python)
+    pick_python() { echo ""; }
+
+    local output
+    output=$(printf '\n' | run_tool "$category" "Test Tool" "https://example.com/tool.py" "python")
+
+    eval "$original_pick_python"
+    BASE_DIR="$original_base_dir"
+    RED="${colors[0]}"; RESET="${colors[1]}"
+    rm -rf "$tmp_dir"
+
+    if [[ "$output" != *"No python interpreter found"* ]]; then
+        printf 'expected missing python warning but got: %s\n' "$output"
+        return 1
+    fi
+
+    return 0
+}
+
+test_cli_help_flag() {
+    local output
+    if ! output=$("$ROOT_DIR/troubleshooter.sh" --help); then
+        printf 'help command failed\n'
+        return 1
+    fi
+
+    if [[ "$output" != *"Usage: troubleshooter.sh"* ]]; then
+        printf 'help output missing usage line\n'
+        return 1
+    fi
+
+    if [[ "$output" != *"-V, --version"* ]]; then
+        printf 'help output missing version flag documentation\n'
+        return 1
+    fi
+
+    return 0
+}
+
 # ---------------------------------------------------------------------------
 
 main() {
     local tests=(
         test_detect_runtime_respects_explicit
         test_detect_runtime_inferrs_extension
+        test_detect_runtime_defaults_to_bash
+        test_pick_python_prefers_python3
+        test_load_categories_sorts_and_appends_all
         test_draw_menu_survives_clear_failure
-        test_run_tool_handles_failing_cached_script
+        test_draw_menu_includes_version_and_context
         test_load_tools_handles_empty_search
+        test_load_tools_paginates_results
+        test_load_tools_search_filters_results
+        test_run_tool_handles_failing_cached_script
+        test_run_tool_uses_cached_copy_by_default
+        test_run_tool_re_downloads_on_request
+        test_run_tool_reports_missing_python
         test_cli_version_flag
+        test_cli_help_flag
     )
 
     local test

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -258,7 +258,16 @@ CONF
         return 1
     fi
 
-    if [[ "${MENU_OPTIONS[-1]}" != "Back to categories" ]]; then
+    if [[ ${#MENU_OPTIONS[@]} -eq 0 ]]; then
+        printf 'menu options unexpectedly empty\n'
+        PAGE_SIZE="$original_page_size"
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    local last_index=$(( ${#MENU_OPTIONS[@]} - 1 ))
+    if [[ "${MENU_OPTIONS[$last_index]}" != "Back to categories" ]]; then
         printf 'missing back to categories entry\n'
         PAGE_SIZE="$original_page_size"
         CONFIG_FILE="$original_config"
@@ -335,7 +344,15 @@ CONF
         return 1
     fi
 
-    if [[ "${MENU_OPTIONS[-1]}" != "Back to categories" ]]; then
+    if [[ ${#MENU_OPTIONS[@]} -eq 0 ]]; then
+        printf 'search returned an empty menu\n'
+        CONFIG_FILE="$original_config"
+        rm -f "$tmp_conf"
+        return 1
+    fi
+
+    local last_index=$(( ${#MENU_OPTIONS[@]} - 1 ))
+    if [[ "${MENU_OPTIONS[$last_index]}" != "Back to categories" ]]; then
         printf 'missing back navigation for search results\n'
         CONFIG_FILE="$original_config"
         rm -f "$tmp_conf"

--- a/troubleshooter.sh
+++ b/troubleshooter.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 # Ubuntu/Photon, dependency-free (bash + curl; optional python)
 #
 
+SCRIPT_VERSION="1.0.0"
+
 CONFIG_FILE="./tools.conf"
 BASE_DIR="./tools"
 
@@ -79,7 +81,12 @@ detect_runtime() {
 # --- UI ---------------------------------------------------------------------
 draw_menu() {
     clear || true
-    echo "${BOLD}${CYAN}=== Stellar Troubleshoot ===${RESET}"
+    local header="=== Stellar Troubleshoot"
+    if [[ -n "$SCRIPT_VERSION" ]]; then
+        header+=" v$SCRIPT_VERSION"
+    fi
+    header+=" ==="
+    echo "${BOLD}${CYAN}${header}${RESET}"
     echo
 
     if [[ "$MODE" == "tools" ]]; then
@@ -428,5 +435,27 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 fi
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    menu_loop
+    case "${1:-}" in
+        -V|--version)
+            echo "Stellar Troubleshoot $SCRIPT_VERSION"
+            exit 0
+            ;;
+        -h|--help)
+            cat <<'USAGE'
+Stellar Troubleshoot - interactive tool runner
+
+Usage: troubleshooter.sh [options]
+
+Options:
+  -h, --help       Show this help message and exit
+  -V, --version    Print the script version and exit
+
+Running without options starts the interactive menu.
+USAGE
+            exit 0
+            ;;
+        *)
+            menu_loop
+            ;;
+    esac
 fi


### PR DESCRIPTION
## Summary
- introduce a SCRIPT_VERSION constant and surface it in the interactive header
- add --version and --help CLI handling for the troubleshooter script
- document the new flag and cover it with an automated smoke test
- document the versioning workflow for contributors in the README

## Testing
- ./tests/run_tests.sh

------
https://chatgpt.com/codex/tasks/task_e_68e44c301a74832a8d43037366f9a42c